### PR TITLE
refactor: Entity에서 @Setter 제거

### DIFF
--- a/src/main/java/com/restapi/templet/blog/comment/Comment.java
+++ b/src/main/java/com/restapi/templet/blog/comment/Comment.java
@@ -7,11 +7,9 @@ import lombok.*;
 import javax.persistence.*;
 
 @Entity
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
-@Setter
+@EqualsAndHashCode(of = "commentId", callSuper = false)
 public class Comment extends Date {
 
     @Id
@@ -23,4 +21,15 @@ public class Comment extends Date {
     @Column(columnDefinition = "TEXT",nullable = false)
     private String message;
 
+    @Builder
+    public Comment(String commenterId, String message){
+        super();
+        this.commenterId = commenterId;
+        this.message = message;
+    }
+
+    public void updateComment(String message){
+        this.message = message;
+        this.update();
+    }
 }

--- a/src/main/java/com/restapi/templet/blog/comment/CommentDto.java
+++ b/src/main/java/com/restapi/templet/blog/comment/CommentDto.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.persistence.Column;
 
 @Getter
-@Setter
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,9 +14,4 @@ import javax.persistence.Column;
 public class CommentDto {
     private String commenterId;
     private String message;
-
-    public void toEntity(Comment comment){
-        comment.setCommenterId(this.commenterId);
-        comment.setMessage(this.message);
-    }
 }

--- a/src/main/java/com/restapi/templet/blog/comment/CommentService.java
+++ b/src/main/java/com/restapi/templet/blog/comment/CommentService.java
@@ -6,6 +6,7 @@ import com.restapi.templet.exception.CommentNotFoundException;
 import com.restapi.templet.exception.PostNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -16,38 +17,37 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
+    @Transactional
     public Long saveComment(Long postId, CommentDto commentDto) {
         Post post = this.postRepository.findByPostId(postId)
-                .orElseThrow(()->new PostNotFoundException("존재하지 않는 게시글입니다."));
-        Comment comment = new Comment();
-        commentDto.toEntity(comment);
-        comment.setCreatedDate(LocalDateTime.now());
-        comment.setModifiedDate(LocalDateTime.now());
-        Comment addedComment = this.commentRepository.save(comment);
-        post.getComments().add(comment);
-        this.postRepository.save(post);
-        return addedComment.getCommentId();
+                .orElseThrow(() -> new PostNotFoundException("존재하지 않는 게시글입니다."));
+
+        Comment comment = this.commentRepository.save(
+                Comment.builder()
+                        .commenterId(commentDto.getCommenterId())
+                        .message(commentDto.getMessage())
+                        .build());
+
+        return post.addComment(comment);
     }
 
+    @Transactional
     public void updateComment(Long postId, Long commentId, CommentDto commentDto) {
         Post post = this.postRepository.findByPostId(postId)
-                .orElseThrow(()->new PostNotFoundException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new PostNotFoundException("존재하지 않는 게시글입니다."));
         Comment comment = this.commentRepository.findByCommentId(commentId)
-                .orElseThrow(()->new CommentNotFoundException("존재하지 않는 댓글입니다."));
-        post.getComments().remove(comment);
-        commentDto.toEntity(comment);
-        comment.setModifiedDate(LocalDateTime.now());
-        post.getComments().add(this.commentRepository.save(comment));
-        this.postRepository.save(post);
+                .orElseThrow(() -> new CommentNotFoundException("존재하지 않는 댓글입니다."));
+
+        post.updateComment(comment,commentDto.getMessage());
     }
 
+    @Transactional
     public void deleteComment(Long postId, Long commentId) {
         Post post = this.postRepository.findByPostId(postId)
-                .orElseThrow(()->new PostNotFoundException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new PostNotFoundException("존재하지 않는 게시글입니다."));
         Comment comment = this.commentRepository.findByCommentId(commentId)
-                .orElseThrow(()->new CommentNotFoundException("존재하지 않는 댓글입니다."));
+                .orElseThrow(() -> new CommentNotFoundException("존재하지 않는 댓글입니다."));
         post.getComments().remove(comment);
         this.commentRepository.delete(comment);
-        this.postRepository.save(post);
     }
 }

--- a/src/main/java/com/restapi/templet/blog/post/Post.java
+++ b/src/main/java/com/restapi/templet/blog/post/Post.java
@@ -11,11 +11,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
-@Setter
 public class Post extends Date {
     @Id
     @JsonIgnore
@@ -37,12 +34,41 @@ public class Post extends Date {
 
     @JsonIgnore
     @OneToMany
-    @Builder.Default
     @JoinColumn(name = "post_id")
-    private List<Comment> comments = new ArrayList<Comment>();
+    private List<Comment> comments;
+
+    @Builder
+    public Post(String writerId, String title, String body){
+        super();
+        this.writerId = writerId;
+        this.title = title;
+        this.body = body;
+        this.views = (long)0;
+    }
+
+    public void updatePost(String title, String body){
+        this.title = title;
+        this.body = body;
+        this.update();
+    }
+
+    public Long addComment(Comment comment){
+        if(this.comments == null)
+            this.comments = new ArrayList<Comment>();
+        this.comments.add(comment);
+        return comment.getCommentId();
+    }
+
+    public void updateComment(Comment comment, String message){
+        comment.updateComment(message);
+        this.comments.set(this.comments.indexOf(comment),comment);
+    }
 
     public PostDetailDto toDetailDto(){
-        PostDetailDto postDetailDto = PostDetailDto.builder()
+        this.views++;
+        if(this.comments==null)
+            this.comments = new ArrayList<Comment>();
+        return PostDetailDto.builder()
                 .title(this.title)
                 .body(this.body)
                 .wirterId(this.writerId)
@@ -51,6 +77,5 @@ public class Post extends Date {
                 .modifiedDate(this.getModifiedDate())
                 .views(this.views)
                 .build();
-        return postDetailDto;
     }
 }

--- a/src/main/java/com/restapi/templet/blog/post/PostService.java
+++ b/src/main/java/com/restapi/templet/blog/post/PostService.java
@@ -18,38 +18,32 @@ public class PostService {
     private final PostRepository postRepository;
     @Transactional
     public Page<Post> getPosts(Pageable pageable) {
-        Page<Post> posts = this.postRepository.findAll(pageable);
-        return posts;
+        return this.postRepository.findAll(pageable);
     }
 
     @Transactional
     public Long savePost(PostDto postDto) {
-        Post newPost = new Post();
-        postDto.toEntity(newPost);
-        newPost.setViews((long)0);
-        newPost.setCreatedDate(LocalDateTime.now());
-        newPost.setModifiedDate(LocalDateTime.now());
-        Post post= this.postRepository.save(newPost);
-        return post.getPostId();
+        Post newPost = Post.builder()
+                .writerId(postDto.getWriterId())
+                .title(postDto.getTitle())
+                .body(postDto.getBody())
+                .build();
+
+        return this.postRepository.save(newPost).getPostId();
     }
 
     @Transactional
     public PostDetailDto getPost(Long postId) {
         Post post = this.postRepository.findByPostId(postId)
                 .orElseThrow(()->new PostNotFoundException("존재하지 않는 게시글입니다."));
-        post.setViews(post.getViews()+1);
-        PostDetailDto postDetailDto = post.toDetailDto();
-        this.postRepository.save(post);
-        return postDetailDto;
+        return post.toDetailDto();
     }
 
     @Transactional
     public void updatePost(Long postId, PostDto postDto) {
         Post post = this.postRepository.findByPostId(postId)
                 .orElseThrow(()->new PostNotFoundException("존재하지 않는 게시글입니다."));
-        postDto.toEntity(post);
-        post.setModifiedDate(LocalDateTime.now());
-        this.postRepository.save(post);
+        post.updatePost(postDto.getTitle(),postDto.getBody());
     }
 
     @Transactional

--- a/src/main/java/com/restapi/templet/blog/post/dto/PostDto.java
+++ b/src/main/java/com/restapi/templet/blog/post/dto/PostDto.java
@@ -13,10 +13,4 @@ public class PostDto {
     private String title;
     private String writerId;
     private String body;
-
-    public void toEntity(Post post){
-        post.setTitle(this.title);
-        post.setWriterId(this.writerId);
-        post.setBody(this.body);
-    }
 }

--- a/src/main/java/com/restapi/templet/common/Date.java
+++ b/src/main/java/com/restapi/templet/common/Date.java
@@ -12,7 +12,6 @@ import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class Date {
@@ -23,4 +22,13 @@ public class Date {
 
     @LastModifiedDate
     private LocalDateTime modifiedDate;
+
+    public Date(){
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = LocalDateTime.now();
+    }
+
+    protected void update(){
+        this.modifiedDate = LocalDateTime.now();
+    }
 }

--- a/src/test/java/com/restapi/templet/blog/comment/CommentControllerTest.java
+++ b/src/test/java/com/restapi/templet/blog/comment/CommentControllerTest.java
@@ -76,7 +76,7 @@ class CommentControllerTest extends BaseControllerTest {
                         )));
         this.mockMvc.perform(RestDocumentationRequestBuilders.get("/blog/posts/{postId}",post.getPostId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("comments[0].commenterId").value("댓글 작성자"))
+                .andExpect(jsonPath("comments[0].commenterId").value("댓글 작성자1"))
                 .andExpect(jsonPath("comments[0].message").value("댓글 수정 테스트"));
     }
     

--- a/src/test/java/com/restapi/templet/blog/post/PostControllerTest.java
+++ b/src/test/java/com/restapi/templet/blog/post/PostControllerTest.java
@@ -153,7 +153,7 @@ class PostControllerTest extends BaseControllerTest {
         Post post = this.getneratePost(1);
         PostDto postDto = PostDto.builder()
                 .title("수정된 포스트")
-                .writerId("웹마스터")
+                .writerId("작성자1")
                 .body("포스트 수정 테스트입니다.")
                 .build();
 
@@ -175,7 +175,7 @@ class PostControllerTest extends BaseControllerTest {
         this.mockMvc.perform(RestDocumentationRequestBuilders.get("/blog/posts/{postId}",post.getPostId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("title").value("수정된 포스트"))
-                .andExpect(jsonPath("writerId").value("웹마스터"))
+                .andExpect(jsonPath("writerId").value("작성자1"))
                 .andExpect(jsonPath("body").value("포스트 수정 테스트입니다."))
                 .andExpect(jsonPath("views").value(1));
     }

--- a/src/test/java/com/restapi/templet/common/BaseControllerTest.java
+++ b/src/test/java/com/restapi/templet/common/BaseControllerTest.java
@@ -47,10 +47,7 @@ public class BaseControllerTest {
                 .title("게시글"+i)
                 .writerId("작성자"+ i)
                 .body("게시글 본문입니다.")
-                .views((long)0)
                 .build();
-        post.setCreatedDate(LocalDateTime.now());
-        post.setModifiedDate(LocalDateTime.now());
         return this.postRepository.save(post);
     }
 
@@ -60,10 +57,8 @@ public class BaseControllerTest {
                 .commenterId("댓글 작성자"+i)
                 .message(i+"번째 댓글")
                 .build();
-        comment.setCreatedDate(LocalDateTime.now());
-        comment.setModifiedDate(LocalDateTime.now());
         Comment savedComment = this.commentRepository.save(comment);
-        post.getComments().add(savedComment);
+        post.addComment(savedComment);
         this.postRepository.save(post);
         return savedComment.getCommentId();
 


### PR DESCRIPTION
- @Setter는 모든 Setter를 생성해준다.
- 엔티티의 데이터 변경은 엔티티에게 맡겨야 하며, 외부로부터 지켜주어야한다.

기타 코드 간결화